### PR TITLE
Pay optical led

### DIFF
--- a/func_tests/optical_led_test/makefile
+++ b/func_tests/optical_led_test/makefile
@@ -1,0 +1,4 @@
+PROG = optical_led_test
+# SRC should only include necessary files
+SRC = $(addprefix ../../src/,optical_spi.c optical_led.c pwm.c)
+include ../makefile

--- a/func_tests/optical_led_test/makefile
+++ b/func_tests/optical_led_test/makefile
@@ -1,4 +1,4 @@
 PROG = optical_led_test
 # SRC should only include necessary files
-SRC = $(addprefix ../../src/,optical_spi.c optical_led.c pwm.c)
+SRC = $(addprefix ../../src/,optical_led.c pwm.c optical_adc.c)
 include ../makefile

--- a/func_tests/optical_led_test/optical_led_test.c
+++ b/func_tests/optical_led_test/optical_led_test.c
@@ -1,5 +1,8 @@
 /*
-DESCRIPTION: toggles LEDs on pay-optical
+DESCRIPTION: toggles LEDs on/off on both PAY-LED boards in sequence
+            - if you have only 1 board plugged it, it'll toggle those LEDs
+            - then nothing will seem to happen
+            - but it's actually trying to toggle the LED's on the other board, that's not plugged in
 AUTHOR: Yong Da Li
 */
 
@@ -8,30 +11,133 @@ AUTHOR: Yong Da Li
 #include <uart/uart.h>
 #include <spi/spi.h>
 
+#include <test/test.h>
+
 #ifndef F_CPU
 #define F_CPU 8000000UL //8 MHz clock
 #endif
 
+
+void print_dirs() {
+    print("bottom PEX - GPA Directions: %.2x\n", read_pex_register(&bot_pex, PEX_IODIR_A));
+    print("bottom PEX - GPB Directions: %.2x\n", read_pex_register(&bot_pex, PEX_IODIR_B));
+
+    print("top PEX - GPA Directions: %.2x\n", read_pex_register(&top_pex, PEX_IODIR_A));
+    print("top PEX - GPB Directions: %.2x\n", read_pex_register(&top_pex, PEX_IODIR_B));
+}
+
+
+void print_values() {
+    print("bottom PEX - GPA Values: %.2x\n", read_pex_register(&bot_pex, PEX_GPIO_A));
+    print("top PEX - GPB Values: %.2x\n", read_pex_register(&bot_pex, PEX_GPIO_B));
+
+    print("top PEX - GPA Values: %.2x\n", read_pex_register(&top_pex, PEX_GPIO_A));
+    print("top PEX - GPB Values: %.2x\n", read_pex_register(&top_pex, PEX_GPIO_B));
+}
+
+
 int main(void){
-    init_uart();
-    print("\n\nUART initialized\n");
+    // UART line and PWM line are the same
+    // so either you have print statements (UART init) or you turn the LED"s on (PWM)
+    // you can't have both
+    // init_uart();
+    // print("\n\nUART initialized\n");
 
     init_spi();
-    print("SPI Initialized\n");
-    print("\n");
+    // print("SPI Initialized\n");
+    // print("\n");
 
-    print("Starting test\n");
+    // print("Starting test\n");
 
     init_opt_led();
+    // print("Optical PEX initialized\n");
+    
+    uint8_t i = 0;
+    while(1){
+        //high
+        //print("\npin high: %d\n", i);
+        opt_led_board_position_on(i);
+        _delay_ms(100);
+
+        //low
+        //print("\noutput: %d\n", i);
+        opt_led_board_position_off(i);
+        _delay_ms(100);
+
+        i++;
+        if (i>35)
+            i = 0;
+    }
+    
+   return 0;
+}
+
+/* this is what the actual SPI communication looks like
+
+    LED's on or off
+        pull CS low (start communications)
+        send --> write control byte
+        send --> address of register
+        send --> state you want (1 = high, 0 = low)
+        pull CS high (end communications)
+
+    reading registers
+        pull CS low (start communications)
+        send --> read control byte
+        send --> address of register
+        send --> blank 8 bits, data back is the register data
+        pull CS high (end communications)
 
     while(1){
-        // toggle all LED's on/off from left-to-right, top-down
-        // *actualy 34 LEDs and 2 empty spots
-        for (uint8_t i = 0; i<36; i++){
-            opt_led_board_position_on(i);
-            _delay_ms(250);
-            opt_led_board_position_off(i);
-        }
-    }
-   
-}
+        set_cs_low(PD1, &PORTD);
+        send_spi(PEX_WRITE_CONTROL_BYTE | (2 << 1) );
+        send_spi(PEX_GPIO_A);
+        send_spi(0xf0);
+        set_cs_high(PD1, &PORTD);
+        _delay_us(500);
+
+        set_cs_low(PD1, &PORTD);
+        send_spi(PEX_READ_CONTROL_BYTE | (2 << 1) );
+        send_spi(PEX_GPIO_A);
+        uint8_t data = send_spi(0x00);
+        set_cs_high(PD1, &PORTD);
+
+        print("data: 0x %.2X\n", data);
+        _delay_ms(1000);
+    }*/
+
+//============================================
+
+// test code to see that registers are writing
+    /*
+    pex_bank_t bank = PEX_A;
+    pex_dir_t dir = OUTPUT;
+    uint8_t state = 0;
+    uint8_t reg = 0;
+    uint8_t pin = 1;
+
+    dir = OUTPUT;
+    // print("\npin mode %d, bank A --> output\n", pin);
+    set_pex_pin_dir(&bot_pex1, bank, pin, dir);
+    reg = read_pex_register(&bot_pex1, PEX_IODIR_A);
+    // print("0x %.2X\n", reg);
+
+    
+    while(1){
+        print("\npin mode %d, bank A --> output: OFF\n", pin);
+        set_pex_pin(&bot_pex1, bank, pin, 0);
+        _delay_ms(5);
+        state = get_pex_pin(&bot_pex1, bank, pin);
+        print("0x %.2X\n", state);
+
+        _delay_ms(500);
+
+        print("\npin mode %d, bank A --> output: ON\n", pin);
+        //(address of pex, bank A or B, pex pin, 1 = high | 0 = low)
+        set_pex_pin(&bot_pex1, bank, pin, 1);
+        _delay_ms(5);
+        state = get_pex_pin(&bot_pex1, bank, pin);
+        print("0x %.2X\n", state);
+
+        _delay_ms(500);
+    }*/

--- a/func_tests/optical_led_test/optical_led_test.c
+++ b/func_tests/optical_led_test/optical_led_test.c
@@ -4,7 +4,7 @@ AUTHOR: Yong Da Li
 */
 
 #include "../../src/optical_led.h"
-#include <util.delay.h>
+#include <utilities/utilities.h>
 #include <uart/uart.h>
 #include <spi/spi.h>
 

--- a/func_tests/optical_led_test/optical_led_test.c
+++ b/func_tests/optical_led_test/optical_led_test.c
@@ -1,12 +1,8 @@
 /*
-<<<<<<< HEAD
 DESCRIPTION: toggles LEDs on/off on both PAY-LED boards in sequence
             - if you have only 1 board plugged it, it'll toggle those LEDs
             - then nothing will seem to happen
             - but it's actually trying to toggle the LED's on the other board, that's not plugged in
-=======
-DESCRIPTION: toggles LEDs on pay-optical
->>>>>>> 7d70bae303926148029f5f67d9ad074b6b401c35
 AUTHOR: Yong Da Li
 */
 

--- a/func_tests/optical_led_test/optical_led_test.c
+++ b/func_tests/optical_led_test/optical_led_test.c
@@ -1,0 +1,37 @@
+/*
+DESCRIPTION: toggles LEDs on pay-optical
+AUTHOR: Yong Da Li
+*/
+
+#include "../../src/optical_led.h"
+#include <util.delay.h>
+#include <uart/uart.h>
+#include <spi/spi.h>
+
+#ifndef F_CPU
+#define F_CPU 8000000UL //8 MHz clock
+#endif
+
+int main(void){
+    init_uart();
+    print("\n\nUART initialized\n");
+
+    init_spi();
+    print("SPI Initialized\n");
+    print("\n");
+
+    print("Starting test\n");
+
+    init_opt_led();
+
+    while(1){
+        // toggle all LED's on/off from left-to-right, top-down
+        // *actualy 34 LEDs and 2 empty spots
+        for (uint8_t i = 0; i<36; i++){
+            opt_led_board_position_on(i);
+            _delay_ms(250);
+            opt_led_board_position_off(i);
+        }
+    }
+   
+}

--- a/src/optical_led.c
+++ b/src/optical_led.c
@@ -277,7 +277,6 @@ void opt_led_board_position_off(uint8_t pos){
 }
 
 
-<<<<<<< HEAD
 // print state of specified pex pin
 void read_pex_pin(uint8_t pos){
     pexpin_t pexpin = mf_channel_switcher[pos];

--- a/src/optical_led.c
+++ b/src/optical_led.c
@@ -9,19 +9,10 @@ PEX datasheet: http://ww1.microchip.com/downloads/en/DeviceDoc/20001952C.pdf
 The PEX has 16 output channels. That means 2 of the LED will turn on together.
 *there's actually 36 LED slots, but only 34 are populated --> 2 empty slots 
 
-<<<<<<< HEAD
 Accepts input format:
 the physical location of the LED on the board, as uint8_t
     ex. 3rd from top left = 4
     ex. 1st on bottom row = 18
-=======
-Accepts channel number (ex. A1_2) 
-    or 
-the physical location of the LED on the board.
-ex. 3rd from top left = 4
-ex. 1st on bottom row = 18
-
->>>>>>> 7d70bae303926148029f5f67d9ad074b6b401c35
 
 LED clock frequency = ~504 Hz (504 + 1/31 Hz)
 PEX (port expander) with address 0b011 = 3 is on top edge of PAY-SSM

--- a/src/optical_led.c
+++ b/src/optical_led.c
@@ -25,7 +25,6 @@ PEX (port expander) with address 0b010 = 2 is on bottom edge of PAY-SSM
 #include "pwm.h"
 #include "optical_led.h"
 
-//only 1 PEX right now, need to implememt 2 PEX control
 //preamble for PEX
 pin_info_t cs = {
     .port = &PEX_CS_PORT_PAY_OPT,
@@ -51,7 +50,51 @@ pex_t bot_pex = {
     .rst = &rst
 };
 
-char mf_channel [4]= "A2_4"; // defaults to LED on top-left of pay-led
+pexpin_t mf_channel_switcher[] = {
+    //top left of pay-led board
+    A2_4,
+    A2_1,
+    A2_2,
+    A2_3,
+    A2_6,
+    A2_8,
+    A2_5,
+    A2_7,
+    A3_1,
+
+    //top right of pay-led board
+    A3_4,
+    A3_2,
+    A3_3,
+    A3_6,
+    A3_8,
+    A3_7,
+    A3_5,
+    A5_1,
+    NO_CHANNEL,
+
+    //bottom left of pay-led board
+    A1_3,
+    A1_2,
+    A1_1,
+    A1_4,
+    A1_6,
+    A1_8,
+    A1_7,
+    A1_5,
+    A4_2,
+
+    //bottom right of pay-led board
+    A4_3,
+    A4_1,
+    A4_4,
+    A4_6,
+    A4_8,
+    A4_7,
+    A4_5,
+    A5_2,
+    NO_CHANNEL,
+};
 
 /*
 output direction for GPIO ports
@@ -89,8 +132,6 @@ void init_opt_led(void){
     // actually 504 + 1/31 Hz
     init_pwm_8bit(3, 30);
 
-    init_uart();
-    init_spi();
     init_pex(&top_pex); //PEX that goes on lower side of PAY-SSM 
     init_pex(&bot_pex); //PEX that goes on upper side of PAY-SSM (mounted with text upside-down)
 
@@ -117,6 +158,47 @@ void init_opt_led(void){
     }
 }
 
+// mode 0 = output
+// mode 1 = input
+void opt_led_set_mode_by_chn_pos(uint8_t channel_num, uint8_t mode){
+    pexpin_t pexpin = mf_channel_switcher[channel_num];
+    opt_led_set_mode(pexpin, mode);
+}
+
+
+void opt_led_set_mode(pexpin_t pexpin, uint8_t mode){
+    uint8_t pex_addr = (pexpin & PEX_ADDR_MASK) >> 5; // leaves only pex_addr
+    uint8_t pex_pin  = pexpin & PEXPIN_MASK; //leaves only pex_pin
+    pex_t pex = top_pex;    // default to top board
+
+    // (channels) 
+    // pins 0-7 --> GPA, bank A
+    // pins 8-15 --> GPB, bank B
+    pex_bank_t bank = PEX_A; // default PEX_A
+
+    if (pex_pin < 8){
+        bank = PEX_A;
+    }
+    else
+    {
+        bank = PEX_B;
+        pex_pin = pex_pin - 8;
+    }
+
+    //pex_addr 0b010 = 2 --> pex on bottom of pay-ssm
+    //pex_addr 0b011 = 3 --> pex on top of pay-ssm
+    switch(pex_addr){
+        case (BOT_PEX_ADDR):
+            pex = bot_pex;
+            break;
+        case (TOP_PEX_ADDR):
+            pex = top_pex;
+            break;
+    }
+
+    set_pex_pin_dir(&pex, bank, pex_pin, mode);
+}
+
 // enum maps channel number to PEX pin number
 // top PEX has address: A(2), A(1), A(0) = 0b110 --> 3
 // bottom PEX has address: A(2), A(1), A(0) = 0b010 --> 2
@@ -129,7 +211,7 @@ void init_opt_led(void){
 // turn_on = 1 --> turns led on
 // turn_on = 0 --> turns led off
 void opt_led_switch(pexpin_t pexpin, uint8_t turn_on){
-    uint8_t pex_addr = pexpin & PEX_ADDR_MASK;
+    uint8_t pex_addr = (pexpin & PEX_ADDR_MASK) >> 5;
     uint8_t pex_pin  = pexpin & PEXPIN_MASK;
     pex_t pex = top_pex;    // default to top board
 
@@ -153,11 +235,11 @@ void opt_led_switch(pexpin_t pexpin, uint8_t turn_on){
 
     //pex_addr 0b010 = 2 --> pex on bottom of pay-ssm
     //pex_addr 0b011 = 3 --> pex on top of pay-ssm
-    switch(pex_addr >> 5){
-        case (0b010):
+    switch(pex_addr){
+        case (BOT_PEX_ADDR):
             pex = bot_pex;
             break;
-        case (0b011):
+        case (TOP_PEX_ADDR):
             pex = top_pex;
             break;
     }
@@ -196,4 +278,77 @@ void opt_led_board_position_off(uint8_t pos){
     pexpin_t pexpin = mf_channel_switcher[pos];
 
     opt_led_off(pexpin);
+}
+
+
+// print state of specified pex pin
+void read_pex_pin(uint8_t pos){
+    pexpin_t pexpin = mf_channel_switcher[pos];
+
+    uint8_t pex_addr = (pexpin & PEX_ADDR_MASK) >> 5;
+    uint8_t pex_pin  = pexpin & PEXPIN_MASK;
+    pex_t pex = top_pex;    // default to top board
+
+    // (channels) 
+    // pins 1-8 --> GPA, bank A
+    // pins 9-16 --> GPB, bank B
+    pex_bank_t bank = PEX_A;
+
+    //pex_pin = 0 --> NO_CHANNEL, do nothing
+    if (pex_pin == 0){
+        return;
+    }
+    else if (pex_pin < 8){
+        bank = PEX_A;
+    }
+    else
+    {
+        bank = PEX_B;
+        pex_pin = pex_pin - 8;
+    }
+
+    //pex_addr 0b010 = 2 --> pex on bottom of pay-ssm
+    //pex_addr 0b011 = 3 --> pex on top of pay-ssm
+    switch(pex_addr){
+        case (BOT_PEX_ADDR):
+            pex = bot_pex;
+            break;
+        case (TOP_PEX_ADDR):
+            pex = top_pex;
+            break;
+    }
+
+    uint8_t state = get_pex_pin(&pex, bank, pex_pin);
+    print("bank %d pin %d --> state %d\n", bank, pex_pin, state);
+}
+
+
+// print state of all pex pins
+void read_all_pex_pins(void){
+    for (uint8_t i = 0; i<36; i++)
+        read_pex_pin(i);
+}
+
+// print state of all registers
+void read_regs(void){
+    uint8_t top_iodir_A = read_pex_register(&top_pex, PEX_IODIR_A);
+    uint8_t top_iodir_B = read_pex_register(&top_pex, PEX_IODIR_B);
+    uint8_t top_gpio_A = read_pex_register(&top_pex, PEX_GPIO_A);
+    uint8_t top_gpio_B = read_pex_register(&top_pex, PEX_GPIO_B);
+
+    uint8_t bot_iodir_A = read_pex_register(&bot_pex, PEX_IODIR_A);
+    uint8_t bot_iodir_B = read_pex_register(&bot_pex, PEX_IODIR_B);
+    uint8_t bot_gpio_A = read_pex_register(&bot_pex, PEX_GPIO_A);
+    uint8_t bot_gpio_B = read_pex_register(&bot_pex, PEX_GPIO_B);
+
+    print("\nRegisters:\n");
+
+    print("top_iodir_A: 0x%.2X\n", top_iodir_A);
+    print("top_iodir_B: 0x%.2X\n", top_iodir_B);
+    print("top_gpio_A: 0x%.2X\n", top_gpio_A);
+    print("top_gpio_B: 0x%.2X\n", top_gpio_B);
+    print("bot_iodir_A: 0x%.2X\n", bot_iodir_A);
+    print("bot_iodir_B: 0x%.2X\n", bot_iodir_B);
+    print("bot_gpio_A: 0x%.2X\n", bot_gpio_A);
+    print("bot_gpio_B: 0x%.2X\n", bot_gpio_B);
 }

--- a/src/optical_led.c
+++ b/src/optical_led.c
@@ -1,0 +1,314 @@
+/*
+DESCRIPTION: LED control functions for PAY-LED board
+AUTHOR: Yong Da Li
+
+Able to turn LEDs on PAY-LED boards on and off.
+PAY-LED is 2 boards. Each board has 17 LED's and 1 PEX (port expander) 
+PEX datasheet: http://ww1.microchip.com/downloads/en/DeviceDoc/20001952C.pdf
+
+The PEX has 16 output channels. That means 2 of the LED will turn on together.
+*there's actually 36 LED slots, but only 34 are populated --> 2 empty slots 
+
+Accepts channel number (ex. A1_2) 
+    or 
+the physical location of the LED on the board.
+ex. 3rd from top left = 4
+ex. 1st on bottom row = 18
+
+
+LED clock frequency = ~504 Hz (504 + 1/31 Hz)
+PEX (port expander) with address 0b011 = 3 is on top edge of PAY-SSM
+    - mounted with text upside down
+
+PEX (port expander) with address 0b010 = 2 is on bottom edge of PAY-SSM
+    - mounted with text rightside up
+*/
+
+#include "optical_led.h"
+
+//only 1 PEX right now, need to implememt 2 PEX control
+//preamble for PEX
+pin_info_t cs = {
+    .port = &PEX_CS_PORT_PAY,
+    .ddr = &PEX_CS_DDR_PAY,
+    .pin = PEX_CS_PIN_PAY
+};
+
+pin_info_t rst = {
+    .port = &PEX_RST_PORT_PAY,
+    .ddr = &PEX_RST_DDR_PAY,
+    .pin = PEX_RST_PIN_PAY
+};
+
+pex_t pex = {
+    .addr = PEX_ADDR_PAY,
+    .cs = &cs,
+    .rst = &rst
+};
+
+char[4] mf_channel = "A2_4" // defaults to LED on top-left of pay-led
+
+/*
+output direction for GPIO ports
+    OUTPUT = 0
+    INPUT = 1
+
+bank A or bank B of GPIO ports
+    PEX_A = 0
+    PEX_B = 1
+*/
+
+
+void init_opt_led(void){
+    /*
+    init PWM 8-bit 
+
+    Initializes and configures 8-bit timer for fast (single-slope) PWM output
+    with variable frequence and fixed 50% duty cycle
+
+    Prescaler: Divide the system clock (8 MHz) by one of five pre-set constants,
+    (1, 8, 64, 256, 1024), 0 <= prescaler <= 4
+
+    Top: Maximum value to which the counter will go before inverting the waveform,
+    and resetting to 0x00, 0 <= top <= 255
+
+    Frequency = 8/(prescaler * (top + 1) * 2) [Mhz]
+
+    Duty-cyle: Invariably 50%, cannot be changed for this timer
+    in the current configuration
+
+    */
+
+    // desired freq = 504 Hz
+    // 0.000504 MHz = 8 / ( [256] * ([30]+1) *  2) 
+    init_pwm_8bit(3, 30);
+
+    init_uart();
+    init_spi();
+    init_pex(&pex2); //PEX that goes on lower side of PAY-SSM 
+    init_pex(&pex3); //PEX that goes on upper side of PAY-SSM (mounted with text upside-down)
+
+    // PEX2 - set bank A to output
+    for (uint8_t i = 0; i<8; i++)
+        set_pex_pin_dir(&pex2, PEX_A, i, OUTPUT);
+
+    // PEX2 - set bank B to output
+    for (uint8_t i = 0; i<8; i++)
+        set_pex_pin_dir(&pex2, PEX_B, i, OUTPUT);
+
+    // PEX3 - set bank A to output
+    for (uint8_t i = 0; i<8; i++)
+        set_pex_pin_dir(&pex3, PEX_A, i, OUTPUT);
+
+    // PEX3 - set bank B to output
+    for (uint8_t i = 0; i<8; i++)
+        set_pex_pin_dir(&pex3, PEX_B, i, OUTPUT);
+
+    // turn all LED's off, total of 36 LEDs 
+    // *actually only 34 LEDs and 2 empty spots
+    for (uint8_t i = 0; i<36; i++){
+        opt_led_board_position_off(i);
+    }
+}
+
+// enum maps channel number to PEX pin number
+// top PEX has address: A(2), A(1), A(0) = 0b110 --> 3
+// bottom PEX has address: A(2), A(1), A(0) = 0b010 --> 2
+// enum bits encoding:
+// 7    6    5    |  4    3    2    1    0
+// __pex_address__|  ___5 bits for pin number(1-16)____ 
+
+// pex_t* pex = actual PEX data type, contains cs and rst address info
+// pexpin_t = info about which PEX (1 of 2) and which pin to turn on
+// turn_on = 1 --> turns led on
+// turn_on = 0 --> turns led off
+void opt_led_switch(pexpin_t pexpin, uint8_t turn_on){
+    uint8_t pex_addr = pexpin & PEX_ADDR_MASK;
+    uint8_t pex_pin  = pexpin & PEXPIN_MASK;
+    pex_t* pex = NULL;
+
+    // (channels) 
+    // pins 1-8 --> GPA, bank A
+    // pins 9-16 --> GPB, bank B
+    pex_bank_t bank = PEX_A;
+
+    //pex_pin = 0 --> NO_CHANNEL, do nothing
+    if (pex_pin == 0){
+        return;
+    }
+    else if (pex_pin < 8){
+        bank = PEX_A;
+    }
+    else
+    {
+        bank = PEX_B;
+        pex_pin = pex_pin - 8;
+    }
+
+    //pex_addr 0b010 = 2 --> pex on bottom of pay-ssm
+    //pex_addr 0b011 = 3 --> pex on top of pay-ssm
+    switch(pex_addr >> 5){
+        case (0b010):
+            pex = pex2;
+            break;
+        case (0b011):
+            pex = pex3;
+            break;
+    }
+
+    //(address of pex, bank A or B, led pin, 1 = high | 0 = low)
+    sex_pex_pin(&pex, bank, led, turn_on);
+}
+
+
+//turn on LED
+void opt_led_on(pexpin_t pexpin){
+    opt_led_switch(pexpin, 1);
+}
+
+
+// accepts string of microfluidics channel number, ex. A1_2
+void opt_led_mf_on(char[] mf_channel){
+    pexpin_t pexpin = opt_led_convert_mf(mf_channel);
+
+    opt_led_on(pexpin);
+}
+
+
+//turn off LED
+void opt_led_off(pexpin_t pexpin){
+    opt_led_switch(pexpin, 0);
+}
+
+
+// accepts physical position of LED on board (0 - 33, inclusive)
+// numbered left-to-right, top-down
+// *includes the blank LED slot with no actual LED (right end of pay-led board)
+void opt_led_board_position_on(uint8_t pos){
+    char[] mf_channel = mf_channel_switcher[pos];
+    pexpin_t pexpin = opt_led_convert_mf(mf_channel);
+
+    opt_led_on(pexpin);
+}
+
+
+
+// accepts physical position of LED on board (0 - 33, inclusive)
+// numbered left-to-right, top-down
+// *includes the blank LED slot with no actual LED (right end of pay-led board)
+void opt_led_board_position_off(uint8_t pos){
+    mf_channel = mf_channel_switcher[pos];
+    pexpin_t pexpin = opt_led_convert_mf(mf_channel);
+
+    opt_led_off(pexpin);
+}
+
+
+// accepts string of microfluidics channel number, ex. A1_2
+void opt_led_mf_off(char[] mf_channel){
+    pexpin_t pexpin = opt_led_convert_mf(mf_channel);
+
+    opt_led_off(pexpin);
+}
+
+
+// converts microfluidcs channel number (ex. A1_2) to pexpin_t
+pexpin_t opt_led_convert_mf(char[] mf_channel){
+    pexpin_t pexpin = A2_4; //default to LED on top left of board
+
+    switch(mf_channel){
+        //channel group 1
+        case "A1_1":
+            pexpin = A1_1;
+            break;
+        case "A1_2":
+            pexpin = A1_2;
+            break;
+        case "A1_3":
+            pexpin = A1_3;
+            break;
+        case "A1_4":
+            pexpin = A1_4;
+            break;
+        case "A1_5":
+            pexpin = A1_5;
+            break;
+        case "A1_6":
+            pexpin = A1_6;
+            break;
+        case "A1_7":
+            pexpin = A1_7;
+            break;
+
+        //channel group 2
+        case "A2_1":
+            pexpin = A2_1;
+            break;
+        case "A2_2":
+            pexpin = A2_2;
+            break;
+        case "A2_3":
+            pexpin = A2_3;
+            break;
+        case "A2_4":
+            pexpin = A2_4;
+            break;
+        case "A2_5":
+            pexpin = A2_5;
+            break;
+        case "A2_6":
+            pexpin = A2_6;
+            break;
+        case "A2_7":
+            pexpin = A2_7;
+            break;
+
+        //channel group 3
+        case "A3_1":
+            pexpin = A3_1;
+            break;
+        case "A3_2":
+            pexpin = A3_2;
+            break;
+        case "A3_3":
+            pexpin = A3_3;
+            break;
+        case "A3_4":
+            pexpin = A3_4;
+            break;
+        case "A3_5":
+            pexpin = A3_5;
+            break;
+        case "A3_6":
+            pexpin = A3_6;
+            break;
+        case "A3_7":
+            pexpin = A3_7;
+            break;
+
+        //channel group 4
+        case "A3_1":
+            pexpin = A3_1;
+            break;
+        case "A3_2":
+            pexpin = A3_2;
+            break;
+        case "A3_3":
+            pexpin = A3_3;
+            break;
+        case "A3_4":
+            pexpin = A3_4;
+            break;
+        case "A3_5":
+            pexpin = A3_5;
+            break;
+        case "A3_6":
+            pexpin = A3_6;
+            break;
+        case "A3_7":
+            pexpin = A3_7;
+            break;
+    }
+
+    return pexpin;
+}

--- a/src/optical_led.h
+++ b/src/optical_led.h
@@ -1,0 +1,175 @@
+/*
+DESCRIPTION: Mappings for LEDs on PAY-LED boards
+AUTHOR: Yong Da LI
+
+Three things need to be linked:
+1. (microfluidics) channel number pay-ssm board, ex. A1_2
+2. left-right, top-down numbering of LEDs on the whole board, ex. 3rd LED from top left
+3. pin number of port expander (PEX) that actually turns on the LED
+
+There are 2 PEX's, each with 16 channels of output (32 "switches").
+There are combined 34 LED's on both pay-optical boards.
+The "switch" (aka PEX pin) for the left-most and right-most channels are connected
+i.e. turning on the channel for the left-most LED also turns on the right-most channel.
+    - this is PEX pin 2
+
+optical_led.c accepts 2 input formats:
+1. (microfluidics) channel number, written on the Pay-led board
+    string of channel number (ex "A1_2") maps to a PEX pin, using the struct enum
+
+2. physical location of LED, ex. 3rd from left
+    [Use left to right, top-down numbering. Starting index is 0]
+    leftmost on top = 0
+    3rd from left = 4
+    left on bottom = 18
+    2nd rightmost on bottom = 33
+
+    i'th location in array contains the (microfluidics) channel number string
+
+    *note that the rightmost LED's on the top and bottom do not correspond to a microfluidics channel
+    *but they are still counted in this numbering
+*/
+
+#ifndef OPTICAL_ADC_H
+#define OPTICAL_ADC_H
+#endif
+
+#include <pex/pex.h>
+#include <spi/spi.h>
+#include <uart/uart.h>
+#include <stdint.h>
+
+// 2 constants not actually used
+// freq is set by init_pwm_8bit()
+// duty cycle for 8-bit pwm is fixed at 50%
+#define PWM_LED_CLK     504 // 504 Hz
+#define DUTY_CYCLE      0.5 // 50% duty cycle
+
+#define PEXPIN_MASK     0b00011111 //leaves only pex pin --> zeros first 3 bits
+#define PEX_ADDR_MASK   0b11100000 //leaves only pex address --> zeros last 5 bits
+
+void init_opt_led(void);
+void opt_led_switch(pexpin_t pexpin, uint8_t turn_on);
+
+void opt_led_on(pexpin_t pexpin);
+void opt_led_off(pexpin_t pexpin);
+
+void opt_led_mf_on(char[] mf_channel);
+void opt_led_mf_off(char[] mf_channel);
+void opt_led_board_position_on(uint8_t pos);
+void opt_led_board_position_off(uint8_t pos);
+
+pexpin_t opt_led_convert_mf(char[] mf_channel);
+
+/*
+ADC on pay-optical board has 16 input channels
+will be set in differential mode --> reading = difference in voltage
+pair_num    (AIN+)    (AIN-)
+0            5        6
+1            7        8
+2            9        10
+3            11        12        *AIN13 and AIN14 are not used
+4            15        16
+*/
+
+// A2-4 = use pair_num A"2" + 1 --> pair_num 3 = diff chn 11 and 12 on ADC
+
+// enum maps channel number to PEX pin number
+// top PEX has address: A(2), A(1), A(0) = 0b110 --> 3
+// bottom PEX has address: A(2), A(1), A(0) = 0b010 --> 2
+// enum bits encoding:
+// 7    6    5    |  4    3    2    1    0
+// __pex_address__|  ___5 bits for pin number(1-16)____   
+typedef enum {
+    //channel number = PEX address | PEX pin number
+    A1_1 = 0b010<<5 | 3,
+    A1_2 = 0b010<<5 | 2,
+    A1_3 = 0b010<<5 | 1,
+    A1_4 = 0b010<<5 | 4,
+    A1_5 = 0b010<<5 | 8,
+    A1_6 = 0b010<<5 | 5,
+    A1_7 = 0b010<<5 | 7,
+    A1_8 = 0b010<<5 | 6,
+
+    A2_1 = 0b011<<5 | 1,
+    A2_2 = 0b011<<5 | 16,
+    A2_3 = 0b011<<5 | 15,
+    A2_4 = 0b011<<5 | 2,
+    A2_5 = 0b011<<5 | 12,
+    A2_6 = 0b011<<5 | 14,
+    A2_7 = 0b011<<5 | 11,
+    A2_8 = 0b011<<5 | 13,
+
+    A3_1 = 0b011<<5 | 10,
+    A3_2 = 0b011<<5 | 8,
+    A3_3 = 0b011<<5 | 7,
+    A3_4 = 0b011<<5 | 9,
+    A3_5 = 0b011<<5 | 3,
+    A3_6 = 0b011<<5 | 6,
+    A3_7 = 0b011<<5 | 4,
+    A3_8 = 0b011<<5 | 5,
+
+    A4_1 = 0b010<<5 | 11,
+    A4_2 = 0b010<<5 | 9,
+    A4_3 = 0b010<<5 | 10,
+    A4_4 = 0b010<<5 | 12,
+    A4_5 = 0b010<<5 | 16,
+    A4_6 = 0b010<<5 | 13,
+    A4_7 = 0b010<<5 | 15,
+    A4_8 = 0b010<<5 | 14,
+
+    A5_1 = 0b011<<5 | 2,
+    A5_2 = 0b010<<5 | 1,
+
+    //no channel number is all 0
+    NO_CHANNEL = 0,
+} pexpin_t;
+
+
+// 5th index contains channel number of the 5th microfluidics channel
+// physically on the pay-led board
+pexpin_t [] mf_channel_switcher = {
+    //top left of pay-led board
+    A2_4,
+    A2_1,
+    A2_2,
+    A2_3,
+    A2_6,
+    A2_8,
+    A2_5,
+    A2_7,
+    A3_1,
+
+    //top right of pay-led board
+    A3_4,
+    A3_2,
+    A3_3,
+    A3_6,
+    A3_8,
+    A3_7,
+    A3_5,
+    A5_1,
+    NO_CHANNEL,
+
+    //bottom left of pay-led board
+    A1_3,
+    A1_2,
+    A1_1,
+    A1_4,
+    A1_6,
+    A1_8,
+    A1_7,
+    A1_5,
+    A4_2,
+
+    //bottom right of pay-led board
+    A4_3,
+    A4_1,
+    A4_4,
+    A4_6,
+    A4_8,
+    A4_7,
+    A4_5,
+    A5_2,
+    NO_CHANNEL,
+}

--- a/src/optical_led.h
+++ b/src/optical_led.h
@@ -3,31 +3,20 @@ DESCRIPTION: Mappings for LEDs on PAY-LED boards
 AUTHOR: Yong Da LI
 
 Three things need to be linked:
-<<<<<<< HEAD
-1. (microfluidics) channel number on PAYY-SSM board, ex. A1_2
-=======
 1. (microfluidics) channel number pay-ssm board, ex. A1_2
 >>>>>>> 7d70bae303926148029f5f67d9ad074b6b401c35
 2. left-right, top-down numbering of LEDs on the whole board, ex. 3rd LED from top left
 3. pin number of port expander (PEX) that actually turns on the LED
 
 There are 2 PEX's, each with 16 channels of output (32 "switches").
-<<<<<<< HEAD
-There are combined 34 LED's on both pay-optical boards. *Actually 36 LED slots, but only 34 are populated --> 2 empty slots
-=======
 There are combined 34 LED's on both pay-optical boards.
->>>>>>> 7d70bae303926148029f5f67d9ad074b6b401c35
 The "switch" (aka PEX pin) for the left-most and right-most channels are connected
 i.e. turning on the channel for the left-most LED also turns on the right-most channel.
     - this is PEX pin 2
 
 optical_led.c accepts 2 input formats:
 1. (microfluidics) channel number, written on the Pay-led board
-<<<<<<< HEAD
     channel number (ex "A1_2") maps to a PEX pin, using the struct enum (pexpin_t datatype)
-=======
-    string of channel number (ex "A1_2") maps to a PEX pin, using the struct enum
->>>>>>> 7d70bae303926148029f5f67d9ad074b6b401c35
 
 2. physical location of LED, ex. 3rd from left
     [Use left to right, top-down numbering. Starting index is 0]

--- a/src/optical_led.h
+++ b/src/optical_led.h
@@ -4,7 +4,6 @@ AUTHOR: Yong Da LI
 
 Three things need to be linked:
 1. (microfluidics) channel number pay-ssm board, ex. A1_2
->>>>>>> 7d70bae303926148029f5f67d9ad074b6b401c35
 2. left-right, top-down numbering of LEDs on the whole board, ex. 3rd LED from top left
 3. pin number of port expander (PEX) that actually turns on the LED
 

--- a/src/optical_led.h
+++ b/src/optical_led.h
@@ -15,7 +15,7 @@ i.e. turning on the channel for the left-most LED also turns on the right-most c
 
 optical_led.c accepts 2 input formats:
 1. (microfluidics) channel number, written on the Pay-led board
-    string of channel number (ex "A1_2") maps to a PEX pin, using the struct enum
+    channel number (ex "A1_2") maps to a PEX pin, using the struct enum (pexpin_t datatype)
 
 2. physical location of LED, ex. 3rd from left
     [Use left to right, top-down numbering. Starting index is 0]
@@ -30,8 +30,8 @@ optical_led.c accepts 2 input formats:
     *but they are still counted in this numbering
 */
 
-#ifndef OPTICAL_ADC_H
-#define OPTICAL_ADC_H
+#ifndef OPTICAL_LED_H
+#define OPTICAL_LED_H
 #endif
 
 #include <pex/pex.h>
@@ -39,26 +39,20 @@ optical_led.c accepts 2 input formats:
 #include <uart/uart.h>
 #include <stdint.h>
 
-// 2 constants not actually used
-// freq is set by init_pwm_8bit()
-// duty cycle for 8-bit pwm is fixed at 50%
-#define PWM_LED_CLK     504 // 504 Hz
-#define DUTY_CYCLE      0.5 // 50% duty cycle
-
 #define PEXPIN_MASK     0b00011111 //leaves only pex pin --> zeros first 3 bits
 #define PEX_ADDR_MASK   0b11100000 //leaves only pex address --> zeros last 5 bits
 
-// top dir = PAY-SSM and PAY-OPTICAL's text is right-side up
-#define TOP_PEX_ADDR      0b110    // hardware set 0b110 = 3 is PAY-LED board that goes on top
+// top = PAY-SSM and PAY-OPTICAL's text is right-side up
+#define TOP_PEX_ADDR      0b011    // hardware set 0b110 = 3 is PAY-LED board that goes on top
 #define BOT_PEX_ADDR      0b010    // hardware set 0b010 = 2 is PAY-LED board that goes on top
 
 #define PEX_CS_PORT_PAY_OPT     PORTD
 #define PEX_CS_DDR_PAY_OPT      DDRD
-#define PEX_CS_PIN_PAY_OPT      PD5
+#define PEX_CS_PIN_PAY_OPT      PD1     // not actually PD5, schematics are wrong, we probed 32m1 against outgoing connector
 
 #define PEX_RST_PORT_PAY_OPT    PORTD
 #define PEX_RST_DDR_PAY_OPT     DDRD
-#define PEX_RST_PIN_PAY_OPT     PD7
+#define PEX_RST_PIN_PAY_OPT     PD5     // not actually PD7, schematics are wrong, we probed 32m1 against outgoing connector
 
 /*
 ADC on pay-optical board has 16 input channels
@@ -81,99 +75,64 @@ pair_num    (AIN+)    (AIN-)
 // __pex_address__|  ___5 bits for pin number(1-16)____   
 typedef enum {
     //channel number = PEX address | PEX pin number
-    A1_1 = 0b010<<5 | 3,
-    A1_2 = 0b010<<5 | 2,
-    A1_3 = 0b010<<5 | 1,
-    A1_4 = 0b010<<5 | 4,
-    A1_5 = 0b010<<5 | 8,
-    A1_6 = 0b010<<5 | 5,
-    A1_7 = 0b010<<5 | 7,
-    A1_8 = 0b010<<5 | 6,
+    A1_1 = BOT_PEX_ADDR<<5 | 3,
+    A1_2 = BOT_PEX_ADDR<<5 | 2,
+    A1_3 = BOT_PEX_ADDR<<5 | 1,
+    A1_4 = BOT_PEX_ADDR<<5 | 4,
+    A1_5 = BOT_PEX_ADDR<<5 | 8,
+    A1_6 = BOT_PEX_ADDR<<5 | 5,
+    A1_7 = BOT_PEX_ADDR<<5 | 7,
+    A1_8 = BOT_PEX_ADDR<<5 | 6,
 
-    A2_1 = 0b011<<5 | 1,
-    A2_2 = 0b011<<5 | 16,
-    A2_3 = 0b011<<5 | 15,
-    A2_4 = 0b011<<5 | 2,
-    A2_5 = 0b011<<5 | 12,
-    A2_6 = 0b011<<5 | 14,
-    A2_7 = 0b011<<5 | 11,
-    A2_8 = 0b011<<5 | 13,
+    A2_1 = TOP_PEX_ADDR<<5 | 1,
+    A2_2 = TOP_PEX_ADDR<<5 | 16,
+    A2_3 = TOP_PEX_ADDR<<5 | 15,
+    A2_4 = TOP_PEX_ADDR<<5 | 2,
+    A2_5 = TOP_PEX_ADDR<<5 | 12,
+    A2_6 = TOP_PEX_ADDR<<5 | 14,
+    A2_7 = TOP_PEX_ADDR<<5 | 11,
+    A2_8 = TOP_PEX_ADDR<<5 | 13,
 
-    A3_1 = 0b011<<5 | 10,
-    A3_2 = 0b011<<5 | 8,
-    A3_3 = 0b011<<5 | 7,
-    A3_4 = 0b011<<5 | 9,
-    A3_5 = 0b011<<5 | 3,
-    A3_6 = 0b011<<5 | 6,
-    A3_7 = 0b011<<5 | 4,
-    A3_8 = 0b011<<5 | 5,
+    A3_1 = TOP_PEX_ADDR<<5 | 10,
+    A3_2 = TOP_PEX_ADDR<<5 | 8,
+    A3_3 = TOP_PEX_ADDR<<5 | 7,
+    A3_4 = TOP_PEX_ADDR<<5 | 9,
+    A3_5 = TOP_PEX_ADDR<<5 | 3,
+    A3_6 = TOP_PEX_ADDR<<5 | 6,
+    A3_7 = TOP_PEX_ADDR<<5 | 4,
+    A3_8 = TOP_PEX_ADDR<<5 | 5,
 
-    A4_1 = 0b010<<5 | 11,
-    A4_2 = 0b010<<5 | 9,
-    A4_3 = 0b010<<5 | 10,
-    A4_4 = 0b010<<5 | 12,
-    A4_5 = 0b010<<5 | 16,
-    A4_6 = 0b010<<5 | 13,
-    A4_7 = 0b010<<5 | 15,
-    A4_8 = 0b010<<5 | 14,
+    A4_1 = BOT_PEX_ADDR<<5 | 11,
+    A4_2 = BOT_PEX_ADDR<<5 | 9,
+    A4_3 = BOT_PEX_ADDR<<5 | 10,
+    A4_4 = BOT_PEX_ADDR<<5 | 12,
+    A4_5 = BOT_PEX_ADDR<<5 | 16,
+    A4_6 = BOT_PEX_ADDR<<5 | 13,
+    A4_7 = BOT_PEX_ADDR<<5 | 15,
+    A4_8 = BOT_PEX_ADDR<<5 | 14,
 
-    A5_1 = 0b011<<5 | 2,
-    A5_2 = 0b010<<5 | 1,
+    A5_1 = TOP_PEX_ADDR<<5 | 2,
+    A5_2 = BOT_PEX_ADDR<<5 | 1,
 
     //no channel number is all 0
     NO_CHANNEL = 0,
 } pexpin_t;
 
+extern pex_t top_pex;
+extern pex_t bot_pex;
 
-// 5th index contains channel number of the 5th microfluidics channel
+
+// ith index contains channel number of the ith microfluidics channel
 // physically on the pay-led board
-pexpin_t mf_channel_switcher [] = {
-    //top left of pay-led board
-    A2_4,
-    A2_1,
-    A2_2,
-    A2_3,
-    A2_6,
-    A2_8,
-    A2_5,
-    A2_7,
-    A3_1,
-
-    //top right of pay-led board
-    A3_4,
-    A3_2,
-    A3_3,
-    A3_6,
-    A3_8,
-    A3_7,
-    A3_5,
-    A5_1,
-    NO_CHANNEL,
-
-    //bottom left of pay-led board
-    A1_3,
-    A1_2,
-    A1_1,
-    A1_4,
-    A1_6,
-    A1_8,
-    A1_7,
-    A1_5,
-    A4_2,
-
-    //bottom right of pay-led board
-    A4_3,
-    A4_1,
-    A4_4,
-    A4_6,
-    A4_8,
-    A4_7,
-    A4_5,
-    A5_2,
-    NO_CHANNEL,
-};
+extern pexpin_t mf_channel_switcher [];
 
 void init_opt_led(void);
+
+// mode 0 = output
+// mode 1 = input
+void opt_led_set_mode_by_chn_pos(uint8_t channel_num, uint8_t mode);
+void opt_led_set_mode(pexpin_t pexpin, uint8_t mode);
+
 void opt_led_switch(pexpin_t pexpin, uint8_t turn_on);
 
 void opt_led_on(pexpin_t pexpin);
@@ -181,3 +140,7 @@ void opt_led_off(pexpin_t pexpin);
 
 void opt_led_board_position_on(uint8_t pos);
 void opt_led_board_position_off(uint8_t pos);
+
+void read_regs(void);
+void read_pex_pin(uint8_t pos);
+void read_all_pex_pins(void);

--- a/src/optical_led.h
+++ b/src/optical_led.h
@@ -3,12 +3,12 @@ DESCRIPTION: Mappings for LEDs on PAY-LED boards
 AUTHOR: Yong Da LI
 
 Three things need to be linked:
-1. (microfluidics) channel number pay-ssm board, ex. A1_2
+1. (microfluidics) channel number on PAYY-SSM board, ex. A1_2
 2. left-right, top-down numbering of LEDs on the whole board, ex. 3rd LED from top left
 3. pin number of port expander (PEX) that actually turns on the LED
 
 There are 2 PEX's, each with 16 channels of output (32 "switches").
-There are combined 34 LED's on both pay-optical boards.
+There are combined 34 LED's on both pay-optical boards. *Actually 36 LED slots, but only 34 are populated --> 2 empty slots
 The "switch" (aka PEX pin) for the left-most and right-most channels are connected
 i.e. turning on the channel for the left-most LED also turns on the right-most channel.
     - this is PEX pin 2
@@ -48,18 +48,17 @@ optical_led.c accepts 2 input formats:
 #define PEXPIN_MASK     0b00011111 //leaves only pex pin --> zeros first 3 bits
 #define PEX_ADDR_MASK   0b11100000 //leaves only pex address --> zeros last 5 bits
 
-void init_opt_led(void);
-void opt_led_switch(pexpin_t pexpin, uint8_t turn_on);
+// top dir = PAY-SSM and PAY-OPTICAL's text is right-side up
+#define TOP_PEX_ADDR      0b110    // hardware set 0b110 = 3 is PAY-LED board that goes on top
+#define BOT_PEX_ADDR      0b010    // hardware set 0b010 = 2 is PAY-LED board that goes on top
 
-void opt_led_on(pexpin_t pexpin);
-void opt_led_off(pexpin_t pexpin);
+#define PEX_CS_PORT_PAY_OPT     PORTD
+#define PEX_CS_DDR_PAY_OPT      DDRD
+#define PEX_CS_PIN_PAY_OPT      PD5
 
-void opt_led_mf_on(char[] mf_channel);
-void opt_led_mf_off(char[] mf_channel);
-void opt_led_board_position_on(uint8_t pos);
-void opt_led_board_position_off(uint8_t pos);
-
-pexpin_t opt_led_convert_mf(char[] mf_channel);
+#define PEX_RST_PORT_PAY_OPT    PORTD
+#define PEX_RST_DDR_PAY_OPT     DDRD
+#define PEX_RST_PIN_PAY_OPT     PD7
 
 /*
 ADC on pay-optical board has 16 input channels
@@ -128,7 +127,7 @@ typedef enum {
 
 // 5th index contains channel number of the 5th microfluidics channel
 // physically on the pay-led board
-pexpin_t [] mf_channel_switcher = {
+pexpin_t mf_channel_switcher [] = {
     //top left of pay-led board
     A2_4,
     A2_1,
@@ -172,4 +171,13 @@ pexpin_t [] mf_channel_switcher = {
     A4_5,
     A5_2,
     NO_CHANNEL,
-}
+};
+
+void init_opt_led(void);
+void opt_led_switch(pexpin_t pexpin, uint8_t turn_on);
+
+void opt_led_on(pexpin_t pexpin);
+void opt_led_off(pexpin_t pexpin);
+
+void opt_led_board_position_on(uint8_t pos);
+void opt_led_board_position_off(uint8_t pos);


### PR DESCRIPTION
PAY-OPTICAL led library

- used PEX on PAY-OPTICAL board to turn on and off LEDs
- created mapping between PEX output pins, microfluidics channel number (ex. "A1_3"), and the position on the board
- can toggle LEDs based on mf channel number or position on the board (i.e. 3 = 4th from top left)
- created struct enum pexpin_t to encode PEX output pins and PEX hardware address